### PR TITLE
Show welcome screen only on first launch, refactor SharedPreferences …

### DIFF
--- a/lib/core/app/app.dart
+++ b/lib/core/app/app.dart
@@ -17,9 +17,9 @@ class App extends StatelessWidget {
         BlocProvider(create: (context) => di.getIt<FavoritesCubit>()),
       ],
       child: MaterialApp(
-        debugShowCheckedModeBanner: false,
-        title: AppConfig.appName,
-        theme: AppConfig.lightTheme,
+      debugShowCheckedModeBanner: false,
+      title: AppConfig.appName,
+      theme: AppConfig.lightTheme,
         initialRoute: Routes.home,
         routes: {
           Routes.home: (context) => const QuoteScreen(),

--- a/lib/core/di/injection_container.dart
+++ b/lib/core/di/injection_container.dart
@@ -4,10 +4,16 @@ import '../network/api_client.dart';
 import '../network/dio_provider.dart';
 import '../../features/quotes/quotes.dart';
 import '../../features/favorites/favorites.dart';
+import '../utils/shared_prefs_service.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 final getIt = GetIt.instance;
 
 Future<void> init() async {
+  // Shared Preferences
+  final sharedPrefs = await SharedPreferences.getInstance();
+  getIt.registerSingleton<SharedPrefsService>(SharedPrefsService(sharedPrefs));
+
   // Network
   Dio dio = DioProvider.getInstance();
   getIt.registerLazySingleton<Dio>(() => dio);

--- a/lib/core/utils/shared_prefs_service.dart
+++ b/lib/core/utils/shared_prefs_service.dart
@@ -1,0 +1,37 @@
+import 'package:shared_preferences/shared_preferences.dart';
+
+class SharedPrefsService {
+  final SharedPreferences _prefs;
+  SharedPrefsService(this._prefs);
+
+  // Bool
+  bool getBool(String key, {bool defaultValue = false}) =>
+      _prefs.getBool(key) ?? defaultValue;
+  Future<void> setBool(String key, bool value) => _prefs.setBool(key, value);
+
+  // Int
+  int getInt(String key, {int defaultValue = 0}) =>
+      _prefs.getInt(key) ?? defaultValue;
+  Future<void> setInt(String key, int value) => _prefs.setInt(key, value);
+
+  // Double
+  double getDouble(String key, {double defaultValue = 0.0}) =>
+      _prefs.getDouble(key) ?? defaultValue;
+  Future<void> setDouble(String key, double value) => _prefs.setDouble(key, value);
+
+  // String
+  String getString(String key, {String defaultValue = ''}) =>
+      _prefs.getString(key) ?? defaultValue;
+  Future<void> setString(String key, String value) => _prefs.setString(key, value);
+
+  // String List
+  List<String> getStringList(String key, {List<String> defaultValue = const []}) =>
+      _prefs.getStringList(key) ?? defaultValue;
+  Future<void> setStringList(String key, List<String> value) => _prefs.setStringList(key, value);
+
+  // Remove
+  Future<void> remove(String key) => _prefs.remove(key);
+
+  // Clear all
+  Future<void> clear() => _prefs.clear();
+} 

--- a/lib/features/favorites/data/favorites_repository.dart
+++ b/lib/features/favorites/data/favorites_repository.dart
@@ -1,42 +1,44 @@
 import 'dart:convert';
-import 'package:shared_preferences/shared_preferences.dart';
+
 import '../../quotes/data/models/quote_model.dart';
+import 'package:codealpha_random_quote_generator/core/utils/shared_prefs_service.dart';
+import 'package:codealpha_random_quote_generator/core/di/injection_container.dart';
 
 class FavoritesRepository {
   static const String _favoritesKey = 'favorite_quotes';
+  final SharedPrefsService _prefsService;
+
+  FavoritesRepository([SharedPrefsService? prefsService])
+      : _prefsService = prefsService ?? getIt<SharedPrefsService>();
 
   // Fetch all favorite quotes
   Future<List<QuoteModel>> getFavorites() async {
-    final prefs = await SharedPreferences.getInstance();
-    final List<String>? jsonList = prefs.getStringList(_favoritesKey);
-    if (jsonList == null) return [];
+    final List<String> jsonList = _prefsService.getStringList(_favoritesKey);
+    if (jsonList.isEmpty) return [];
     return jsonList.map((jsonStr) => QuoteModel.fromJson(json.decode(jsonStr) as Map<String, dynamic>)).toList();
   }
 
   // Add a quote to favorites
   Future<void> addFavorite(QuoteModel quote) async {
-    final prefs = await SharedPreferences.getInstance();
-    final List<String> jsonList = prefs.getStringList(_favoritesKey) ?? [];
+    final List<String> jsonList = _prefsService.getStringList(_favoritesKey);
     final quoteJson = json.encode(quote.toJson());
     if (!jsonList.contains(quoteJson)) {
       jsonList.add(quoteJson);
-      await prefs.setStringList(_favoritesKey, jsonList);
+      await _prefsService.setStringList(_favoritesKey, jsonList);
     }
   }
 
   // Remove a quote from favorites
   Future<void> removeFavorite(QuoteModel quote) async {
-    final prefs = await SharedPreferences.getInstance();
-    final List<String> jsonList = prefs.getStringList(_favoritesKey) ?? [];
+    final List<String> jsonList = _prefsService.getStringList(_favoritesKey);
     final quoteJson = json.encode(quote.toJson());
     jsonList.remove(quoteJson);
-    await prefs.setStringList(_favoritesKey, jsonList);
+    await _prefsService.setStringList(_favoritesKey, jsonList);
   }
 
   // Check if a quote is in favorites
   Future<bool> isFavorite(QuoteModel quote) async {
-    final prefs = await SharedPreferences.getInstance();
-    final List<String> jsonList = prefs.getStringList(_favoritesKey) ?? [];
+    final List<String> jsonList = _prefsService.getStringList(_favoritesKey);
     final quoteJson = json.encode(quote.toJson());
     return jsonList.contains(quoteJson);
   }

--- a/lib/features/quotes/ui/screens/quote_screen.dart
+++ b/lib/features/quotes/ui/screens/quote_screen.dart
@@ -5,9 +5,42 @@ import '../../logic/cubit/quote_cubit.dart';
 import '../../logic/cubit/quote_state.dart';
 import '../../../../core/app/routes.dart';
 import '../../../../core/config/ui_constants.dart';
+import '../../../../core/utils/shared_prefs_service.dart';
+import '../../../../core/di/injection_container.dart';
 
-class QuoteScreen extends StatelessWidget {
+class QuoteScreen extends StatefulWidget {
   const QuoteScreen({super.key});
+
+  @override
+  State<QuoteScreen> createState() => _QuoteScreenState();
+}
+
+class _QuoteScreenState extends State<QuoteScreen> {
+  bool? _showWelcome;
+
+  @override
+  void initState() {
+    super.initState();
+    _checkFirstLaunch();
+  }
+
+  Future<void> _checkFirstLaunch() async {
+    final prefsService = getIt<SharedPrefsService>();
+    final isFirstLaunch = prefsService.getBool('is_first_launch', defaultValue: true);
+    if (isFirstLaunch) {
+      setState(() {
+        _showWelcome = true;
+      });
+      await prefsService.setBool('is_first_launch', false);
+    } else {
+      setState(() {
+        _showWelcome = false;
+      });
+      // Fetch a new quote immediately
+      // ignore: use_build_context_synchronously
+      context.read<QuoteCubit>().fetchRandomQuote();
+    }
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -38,43 +71,47 @@ class QuoteScreen extends StatelessWidget {
             ],
           ),
         ),
-        child: BlocBuilder<QuoteCubit, QuoteState>(
-          builder: (context, state) {
-            return state.when(
-              initial: () => _buildInitialState(context),
-              loading: (isInitial) {
-                if (isInitial) {
-                  return const LoadingWidget(showButtonShimmer: true);
-                } else {
-                  return Padding(
-                    padding: const EdgeInsets.all(16.0),
-                    child: Column(
-                      mainAxisAlignment: MainAxisAlignment.center,
-                      children: [
-                        const Expanded(
-                          child: LoadingWidget(showButtonShimmer: false),
+        child: _showWelcome == null
+            ? const Center(child: CircularProgressIndicator())
+            : _showWelcome!
+                ? _buildInitialState(context)
+                : BlocBuilder<QuoteCubit, QuoteState>(
+                    builder: (context, state) {
+                      return state.when(
+                        initial: () => const SizedBox.shrink(),
+                        loading: (isInitial) {
+                          if (isInitial) {
+                            return const LoadingWidget(showButtonShimmer: true);
+                          } else {
+                            return Padding(
+                              padding: const EdgeInsets.all(16.0),
+                              child: Column(
+                                mainAxisAlignment: MainAxisAlignment.center,
+                                children: [
+                                  const Expanded(
+                                    child: LoadingWidget(showButtonShimmer: false),
+                                  ),
+                                  const SizedBox(height: 24),
+                                  ConstrainedBox(
+                                    constraints: BoxConstraints(maxWidth: kButtonMaxWidth),
+                                    child: NewQuoteButton(
+                                      onPressed: () {
+                                        context.read<QuoteCubit>().fetchRandomQuote();
+                                      },
+                                    ),
+                                  ),
+                                ],
+                              ),
+                            );
+                          }
+                        },
+                        success: (quote) => _buildSuccessState(context, quote),
+                        error: (error) => QuoteErrorWidget(
+                          error: error.statusMessage ?? 'An unknown error occurred',
                         ),
-                        const SizedBox(height: 24),
-                        ConstrainedBox(
-                          constraints: BoxConstraints(maxWidth: kButtonMaxWidth),
-                          child: NewQuoteButton(
-                            onPressed: () {
-                              context.read<QuoteCubit>().fetchRandomQuote();
-                            },
-                          ),
-                        ),
-                      ],
-                    ),
-                  );
-                }
-              },
-              success: (quote) => _buildSuccessState(context, quote),
-              error: (error) => QuoteErrorWidget(
-                error: error.statusMessage ?? 'An unknown error occurred',
-              ),
-            );
-          },
-        ),
+                      );
+                    },
+                  ),
       ),
     );
   }
@@ -100,6 +137,9 @@ class QuoteScreen extends StatelessWidget {
               child: NewQuoteButton(
                 onPressed: () {
                   context.read<QuoteCubit>().fetchRandomQuote();
+                  setState(() {
+                    _showWelcome = false;
+                  });
                 },
               ),
             ),

--- a/test/features/favorites/data/favorites_repository_test.dart
+++ b/test/features/favorites/data/favorites_repository_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:codealpha_random_quote_generator/features/quotes/data/models/quote_model.dart';
 import 'package:codealpha_random_quote_generator/features/favorites/data/favorites_repository.dart';
+import 'package:codealpha_random_quote_generator/core/utils/shared_prefs_service.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 void main() {
@@ -9,12 +10,13 @@ void main() {
   
   group('FavoritesRepository', () {
     late FavoritesRepository repository;
+    late SharedPrefsService prefsService;
 
     setUp(() async {
-      // Clear SharedPreferences before each test
       final prefs = await SharedPreferences.getInstance();
       await prefs.clear();
-      repository = FavoritesRepository();
+      prefsService = SharedPrefsService(prefs);
+      repository = FavoritesRepository(prefsService);
     });
 
     group('QuoteModel equality', () {


### PR DESCRIPTION
…usage

- Show "Welcome to QuoteShot" screen only on the very first app launch; fetch a new random quote immediately on all subsequent launches
- Centralize persistent storage by introducing SharedPrefsService for global, testable SharedPreferences access
- Refactor favorites repository and quote screen to use SharedPrefsService via dependency injection
- Update favorites repository tests to use SharedPrefsService with mock preferences
- Improve maintainability, testability, and follow best practices for state persistence

https://github.com/user-attachments/assets/ced87a12-48af-4561-addf-bf28a34c2e4b

